### PR TITLE
[Oztechan/CCC#4796] Make TerminationException extend CancellationException

### DIFF
--- a/common/core/network/src/commonMain/kotlin/com/oztechan/ccc/common/core/network/error/TerminationException.kt
+++ b/common/core/network/src/commonMain/kotlin/com/oztechan/ccc/common/core/network/error/TerminationException.kt
@@ -1,3 +1,7 @@
 package com.oztechan.ccc.common.core.network.error
 
-internal class TerminationException(cause: Throwable) : Throwable(cause)
+import kotlinx.coroutines.CancellationException
+
+// Maps coroutine cancellation into the project's error taxonomy. Extends CancellationException (not
+// Throwable) so structured concurrency still recognises it as cancellation and unwinds cleanly.
+internal class TerminationException(cause: Throwable) : CancellationException(cause.message)


### PR DESCRIPTION
`BaseNetworkService` maps library exceptions into the project error taxonomy, incl. `is CancellationException -> TerminationException(e)`. But `TerminationException` extended `Throwable`, so a cancelled coroutine threw a **non-cancellation** exception — breaking structured concurrency (parent treats the child as failed, not cancelled) and producing `Parent job is Cancelling` stack-dump noise.

**Fix:** `TerminationException` now extends **`CancellationException`** (via the common `CancellationException(message)` constructor) instead of `Throwable`. The library→project mapping is unchanged, so the abstraction is preserved — but the framework now recognises it as cancellation and unwinds cleanly.

The existing `BaseNetworkServiceTest` (`assertFailsWith(TerminationException::class)`) still holds — cancellation still maps to `TerminationException`.

✅ Verified: `:common:core:network:jvmTest` passes. Mirrors Oztechan/AdTrack#57.

Resolves Oztechan/CCC#4796