### PR TITLE
[Oztechan/CCC#4804] Point Project Automations at Oztechan Apps (#13) with milestone workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,9 +14,8 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project.yml@8610938e630b3ed86127765237fe3647b9fabd4f
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@17e6f5436e23d9f5ded36c820801cdac40fd99cf
     with:
-      project_id: 2
+      project_id: 13
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      NEXT_VERSION: ${{ secrets.NEXT_VERSION }}


### PR DESCRIPTION
Points this repo's Project Automations at the consolidated **Oztechan Apps** project (#13) and adopts the milestone-based reusable workflow (Oztechan/Global#219).

- `project_id: 13` (was 2)
- Bumps the reusable-project.yml Global pin to the new develop SHA (native milestones instead of NEXT_VERSION)
- Drops the removed `NEXT_VERSION` secret usage

Resolves Oztechan/CCC#4804