### PR TITLE
[Oztechan/CCC#4809] Point project automation at merged reusable workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project.yml@17e6f5436e23d9f5ded36c820801cdac40fd99cf
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d2d760603ad21c392c22ab10508941b6f65a3cf1
     with:
       project_id: 13
     secrets:


### PR DESCRIPTION
Closes #4809

Bumps the reusable-project.yml pin to `d2d760603ad21c392c22ab10508941b6f65a3cf1` (Oztechan/Global#225). On PR open the linked issue now stays in `🚧 In Progress` instead of moving to `🏗 PR Review`; only the PR moves to PR Review. project_id and secrets are unchanged.