### PR TITLE
[Oztechan/CCC#4811] Bump project automation pin to fixed workflow SHA

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d5593d5af7576d25ef10aa804c2bf52efe5cf53c
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@6c7b329cd65b22c4cbdf59dda5f9436e54f1c26f
     with:
       project_id: 13
     secrets:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d2d760603ad21c392c22ab10508941b6f65a3cf1
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@d5593d5af7576d25ef10aa804c2bf52efe5cf53c
     with:
       project_id: 13
     secrets:


### PR DESCRIPTION
Closes #4811

Bumps the reusable-project.yml pin from `d2d760603ad21c392c22ab10508941b6f65a3cf1` to `d5593d5af7576d25ef10aa804c2bf52efe5cf53c` (Oztechan/Global#226), which actually contains the fix: on PR open the linked issue stays in `🚧 In Progress` and only the PR moves to `🏗 PR Review`.