### PR TITLE
[Oztechan/CCC#4821] Reuse Global disable-kotlin-incremental-native action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
 
       - name: Disable Kotlin incremental native for CI
-        uses: Oztechan/Global/actions/disable-kotlin-incremental-native@e3f27b10f120bac0deaec90cc8c743dc1aa3a946
+        uses: Oztechan/Global/actions/disable-kotlin-incremental-native@4ddf8deebb68c6630773bdff9d83f8566310b703
 
       - name: Build
         # iOS unit-test binaries transitively link `-framework FirebaseCore` (via GitLive), which is

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,11 +77,7 @@ jobs:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
 
       - name: Disable Kotlin incremental native for CI
-        run: |
-          mkdir -p ~/.gradle
-          touch ~/.gradle/gradle.properties
-          sed -i '' '/kotlin.incremental.native/d' ~/.gradle/gradle.properties
-          echo "kotlin.incremental.native=false" >> ~/.gradle/gradle.properties
+        uses: Oztechan/Global/actions/disable-kotlin-incremental-native@e3f27b10f120bac0deaec90cc8c743dc1aa3a946
 
       - name: Build
         # iOS unit-test binaries transitively link `-framework FirebaseCore` (via GitLive), which is

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,11 +172,7 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_26.6.app
 
       - name: Disable Kotlin incremental native for CI
-        run: |
-          mkdir -p ~/.gradle
-          touch ~/.gradle/gradle.properties
-          sed -i '' '/kotlin.incremental.native/d' ~/.gradle/gradle.properties
-          echo "kotlin.incremental.native=false" >> ~/.gradle/gradle.properties
+        uses: Oztechan/Global/actions/disable-kotlin-incremental-native@e3f27b10f120bac0deaec90cc8c743dc1aa3a946
 
       - name: Build ${{ env.BUILD_TYPE }}
         working-directory: ios

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,7 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_26.6.app
 
       - name: Disable Kotlin incremental native for CI
-        uses: Oztechan/Global/actions/disable-kotlin-incremental-native@e3f27b10f120bac0deaec90cc8c743dc1aa3a946
+        uses: Oztechan/Global/actions/disable-kotlin-incremental-native@4ddf8deebb68c6630773bdff9d83f8566310b703
 
       - name: Build ${{ env.BUILD_TYPE }}
         working-directory: ios


### PR DESCRIPTION
## What

Replaces the inline "Disable Kotlin incremental native for CI" steps in `main.yml` and `build.yml` with the reusable `Oztechan/Global/actions/disable-kotlin-incremental-native` composite action.

## Depends on

- Oztechan/Global#231 (adds the action)

Pinned to the Global branch commit for now; Renovate will re-pin the digest once Global#231 merges to develop.

Closes #4821