### PR TITLE
[Oztechan/CCC#4825] Enable parallel Gradle sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ xcodeproj=./ios
 android.nonTransitiveRClass=false
 # todo need to remove it but currently throws `runtime assert: runtime injected twice; https://youtrack.jetbrains.com/issue/KT-42254 might be related` on XCode
 kotlin.native.cacheKind=none
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Enables parallel Gradle model building during IDE sync (Gradle 9.4+), speeding up sync for this multi-module project.

Closes #4825