### PR TITLE
[Oztechan/CCC#4829] Only request ads when UMP canRequestAds() is true

### DIFF
--- a/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -83,6 +83,8 @@ internal class AdManagerImpl(context: Context) : AdManager {
         }
     }
 
+    override fun canRequestAds() = consentInformation.canRequestAds()
+
     override fun getBannerAd(
         context: Context,
         adId: String,
@@ -132,6 +134,11 @@ internal class AdManagerImpl(context: Context) : AdManager {
         adId: String
     ) {
         Logger.v { "AdManagerImpl showInterstitialAd" }
+
+        if (!canRequestAds()) {
+            Logger.v { "AdManagerImpl showInterstitialAd skipped, cannot request ads" }
+            return
+        }
 
         InterstitialAd.load(
             activity,

--- a/android/core/ad/src/huawei/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/huawei/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -35,6 +35,8 @@ internal class AdManagerImpl : AdManager {
 
     override fun showConsentForm(activity: Activity) = Unit
 
+    override fun canRequestAds() = true
+
     override fun getBannerAd(
         context: Context,
         adId: String,

--- a/android/core/ad/src/main/kotlin/com/oztechan/ccc/android/core/ad/AdManager.kt
+++ b/android/core/ad/src/main/kotlin/com/oztechan/ccc/android/core/ad/AdManager.kt
@@ -11,6 +11,8 @@ interface AdManager {
 
     fun showConsentForm(activity: Activity)
 
+    fun canRequestAds(): Boolean
+
     fun getBannerAd(
         context: Context,
         adId: String,

--- a/android/ui/mobile/src/main/kotlin/com/oztechan/ccc/android/ui/mobile/util/ViewExtensions.kt
+++ b/android/ui/mobile/src/main/kotlin/com/oztechan/ccc/android/ui/mobile/util/ViewExtensions.kt
@@ -64,7 +64,7 @@ fun FrameLayout.buildBanner(
     adManager: AdManager,
     adId: String,
     shouldShowAd: Boolean
-) = if (shouldShowAd) {
+) = if (shouldShowAd && adManager.canRequestAds()) {
     removeAllViews()
     addView(
         adManager.getBannerAd(


### PR DESCRIPTION
## What
Gate banner and interstitial ad requests on `AdManager.canRequestAds()`.

## Why
When `canRequestAds()` is false (consent unresolved or ads blocked), `MobileAds.initialize()` is never called, yet banners/interstitials were still requested — causing failed loads, repeated `onAdFailedToLoad` error logs, and an empty reserved banner slot. This follows Google UMP guidance to only request ads when `canRequestAds()` is true.

## Changes
- `AdManager`: add `canRequestAds(): Boolean`
- Google impl: `consentInformation.canRequestAds()`; early-return in `showInterstitialAd` when it's false
- Huawei impl: returns `true` (no consent flow)
- `buildBanner`: only builds the banner when `shouldShowAd && adManager.canRequestAds()` (otherwise `View.GONE`, no reserved space)

Shared KMP layer untouched, so no viewmodel/repository test changes.

Closes #4829