### PR TITLE
[Oztechan/CCC#4831] Cap Remote Config ad session counts so a bad value can't disable ads

### DIFF
--- a/client/configservice/ad/src/commonMain/kotlin/com/oztechan/ccc/client/configservice/ad/mapper/AdConfigMapper.kt
+++ b/client/configservice/ad/src/commonMain/kotlin/com/oztechan/ccc/client/configservice/ad/mapper/AdConfigMapper.kt
@@ -3,9 +3,13 @@ package com.oztechan.ccc.client.configservice.ad.mapper
 import com.oztechan.ccc.client.configservice.ad.model.AdConfig as AdConfigModel
 import com.oztechan.ccc.client.core.remoteconfig.model.AdConfig as AdConfigRCModel
 
+// Upper-bound safety cap: even if Remote Config ships a mistakenly large value, ads must still
+// start for active users. A value this high is never a legitimate warm-up length, only a misconfig.
+internal const val MAX_AD_SESSION_COUNT = 100
+
 internal fun AdConfigRCModel.toAdConfigModel() = AdConfigModel(
-    bannerAdSessionCount = bannerAdSessionCount,
-    interstitialAdSessionCount = interstitialAdSessionCount,
+    bannerAdSessionCount = bannerAdSessionCount.coerceAtMost(MAX_AD_SESSION_COUNT),
+    interstitialAdSessionCount = interstitialAdSessionCount.coerceAtMost(MAX_AD_SESSION_COUNT),
     interstitialAdInitialDelay = interstitialAdInitialDelay,
     interstitialAdPeriod = interstitialAdPeriod
 )

--- a/client/configservice/ad/src/commonTest/kotlin/com/oztechan/ccc/client/configservice/ad/mapper/AdConfigMapperTest.kt
+++ b/client/configservice/ad/src/commonTest/kotlin/com/oztechan/ccc/client/configservice/ad/mapper/AdConfigMapperTest.kt
@@ -16,4 +16,25 @@ internal class AdConfigMapperTest {
         assertEquals(rcModel.interstitialAdInitialDelay, model.interstitialAdInitialDelay)
         assertEquals(rcModel.interstitialAdPeriod, model.interstitialAdPeriod)
     }
+
+    @Test
+    fun `session counts are capped at MAX_AD_SESSION_COUNT`() {
+        val rcModel = AdConfigRCModel(
+            bannerAdSessionCount = MAX_AD_SESSION_COUNT + 1,
+            interstitialAdSessionCount = Int.MAX_VALUE
+        )
+        val model = rcModel.toAdConfigModel()
+
+        assertEquals(MAX_AD_SESSION_COUNT, model.bannerAdSessionCount)
+        assertEquals(MAX_AD_SESSION_COUNT, model.interstitialAdSessionCount)
+    }
+
+    @Test
+    fun `session counts below the cap are left unchanged`() {
+        val rcModel = AdConfigRCModel(bannerAdSessionCount = 2, interstitialAdSessionCount = 5)
+        val model = rcModel.toAdConfigModel()
+
+        assertEquals(2, model.bannerAdSessionCount)
+        assertEquals(5, model.interstitialAdSessionCount)
+    }
 }


### PR DESCRIPTION
## What
Cap `bannerAdSessionCount` / `interstitialAdSessionCount` at `MAX_AD_SESSION_COUNT = 100` in `AdConfigMapper`.

## Why
Both thresholds come from Firebase Remote Config. A mistakenly large value (e.g. a fat-fingered `999999`) would make `sessionCount > threshold` never true, silently turning **every** non-premium user ad-free worldwide with no app update. The cap guarantees ads start for active users regardless of a bad RC value; 100 sessions is never a legitimate warm-up length, only a misconfig, so it never interferes with real config.

## Note
`100` is a deliberately generous backstop — tune it if you want a tighter ceiling.

Closes #4831