### PR TITLE
[Oztechan/CCC#4833] Retry UMP consent-info update on failure

### DIFF
--- a/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -18,13 +18,14 @@ import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 
+@Suppress("TooManyFunctions")
 internal class AdManagerImpl(
     context: Context,
     private val globalScope: CoroutineScope,

--- a/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -25,13 +25,15 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-internal class AdManagerImpl(context: Context) : AdManager {
+internal class AdManagerImpl(
+    context: Context,
+    private val globalScope: CoroutineScope,
+) : AdManager {
     // Use an atomic boolean to initialize the Google Mobile Ads SDK and load ads once.
     private val isMobileAdsInitializeCalled = AtomicBoolean(false)
 
     private var consentRetryCount = 0
     private var consentRetryJob: Job? = null
-    private val consentScope = CoroutineScope(Dispatchers.Main)
 
     private val consentInformation: ConsentInformation =
         UserMessagingPlatform.getConsentInformation(context)
@@ -96,7 +98,7 @@ internal class AdManagerImpl(context: Context) : AdManager {
         Logger.v { "AdManagerImpl retry consent info update #$consentRetryCount" }
         // Keep a single pending retry: cancel any previous one before scheduling the next.
         consentRetryJob?.cancel()
-        consentRetryJob = consentScope.launch {
+        consentRetryJob = globalScope.launch(Dispatchers.Main) {
             delay(CONSENT_RETRY_DELAY_MS)
             if (!activity.isFinishing && !activity.isDestroyed) {
                 requestConsentInfoUpdate(activity)

--- a/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -3,6 +3,8 @@ package com.oztechan.ccc.android.core.ad
 import android.app.Activity
 import android.content.Context
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.view.WindowManager
 import co.touchlab.kermit.Logger
 import com.google.android.gms.ads.AdListener
@@ -24,6 +26,8 @@ internal class AdManagerImpl(context: Context) : AdManager {
     // Use an atomic boolean to initialize the Google Mobile Ads SDK and load ads once.
     private val isMobileAdsInitializeCalled = AtomicBoolean(false)
 
+    private var consentRetryCount = 0
+
     private val consentInformation: ConsentInformation =
         UserMessagingPlatform.getConsentInformation(context)
 
@@ -37,6 +41,18 @@ internal class AdManagerImpl(context: Context) : AdManager {
 
     override fun initAds(activity: Activity) {
         Logger.v { "AdManagerImpl initAds" }
+        consentRetryCount = 0
+        requestConsentInfoUpdate(activity)
+
+        // Check if you can initialize the Google Mobile Ads SDK in parallel
+        // while checking for new consent information. Consent obtained in
+        // the previous session can be used to request ads.
+        if (consentInformation.canRequestAds()) {
+            activity.initializeMobileAdsSdk()
+        }
+    }
+
+    private fun requestConsentInfoUpdate(activity: Activity) {
         consentInformation.requestConsentInfoUpdate(
             activity,
             ConsentRequestParameters.Builder().build(),
@@ -58,15 +74,26 @@ internal class AdManagerImpl(context: Context) : AdManager {
                 Exception("Consent gathering failed: ${it.errorCode}: ${it.message}").let { exception ->
                     Logger.e(exception) { exception.message.orEmpty() }
                 }
+                // Transient failures (e.g. network) leave canRequestAds() false for the whole
+                // session; retry a bounded number of times so we don't lose ad impressions.
+                retryConsentInfoUpdate(activity)
             }
         )
+    }
 
-        // Check if you can initialize the Google Mobile Ads SDK in parallel
-        // while checking for new consent information. Consent obtained in
-        // the previous session can be used to request ads.
-        if (consentInformation.canRequestAds()) {
-            activity.initializeMobileAdsSdk()
-        }
+    private fun retryConsentInfoUpdate(activity: Activity) {
+        if (consentRetryCount >= MAX_CONSENT_RETRY_COUNT) return
+
+        consentRetryCount++
+        Logger.v { "AdManagerImpl retry consent info update #$consentRetryCount" }
+        Handler(Looper.getMainLooper()).postDelayed(
+            {
+                if (!activity.isFinishing && !activity.isDestroyed) {
+                    requestConsentInfoUpdate(activity)
+                }
+            },
+            CONSENT_RETRY_DELAY_MS
+        )
     }
 
     override fun isPrivacyOptionsRequired() =
@@ -209,5 +236,10 @@ internal class AdManagerImpl(context: Context) : AdManager {
         MobileAds.initialize(this)
         MobileAds.setAppVolume(0.0f)
         MobileAds.setAppMuted(true)
+    }
+
+    private companion object {
+        const val MAX_CONSENT_RETRY_COUNT = 3
+        const val CONSENT_RETRY_DELAY_MS = 3000L
     }
 }

--- a/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -3,8 +3,6 @@ package com.oztechan.ccc.android.core.ad
 import android.app.Activity
 import android.content.Context
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.view.WindowManager
 import co.touchlab.kermit.Logger
 import com.google.android.gms.ads.AdListener
@@ -21,12 +19,19 @@ import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 internal class AdManagerImpl(context: Context) : AdManager {
     // Use an atomic boolean to initialize the Google Mobile Ads SDK and load ads once.
     private val isMobileAdsInitializeCalled = AtomicBoolean(false)
 
     private var consentRetryCount = 0
+    private var consentRetryJob: Job? = null
+    private val consentScope = CoroutineScope(Dispatchers.Main)
 
     private val consentInformation: ConsentInformation =
         UserMessagingPlatform.getConsentInformation(context)
@@ -41,6 +46,9 @@ internal class AdManagerImpl(context: Context) : AdManager {
 
     override fun initAds(activity: Activity) {
         Logger.v { "AdManagerImpl initAds" }
+        // Cancel any retry still pending from a previous initAds so it can't fire on a stale
+        // Activity or exceed the per-launch retry budget.
+        consentRetryJob?.cancel()
         consentRetryCount = 0
         requestConsentInfoUpdate(activity)
 
@@ -86,14 +94,14 @@ internal class AdManagerImpl(context: Context) : AdManager {
 
         consentRetryCount++
         Logger.v { "AdManagerImpl retry consent info update #$consentRetryCount" }
-        Handler(Looper.getMainLooper()).postDelayed(
-            {
-                if (!activity.isFinishing && !activity.isDestroyed) {
-                    requestConsentInfoUpdate(activity)
-                }
-            },
-            CONSENT_RETRY_DELAY_MS
-        )
+        // Keep a single pending retry: cancel any previous one before scheduling the next.
+        consentRetryJob?.cancel()
+        consentRetryJob = consentScope.launch {
+            delay(CONSENT_RETRY_DELAY_MS)
+            if (!activity.isFinishing && !activity.isDestroyed) {
+                requestConsentInfoUpdate(activity)
+            }
+        }
     }
 
     override fun isPrivacyOptionsRequired() =


### PR DESCRIPTION
## What
Extract the consent-info request into `requestConsentInfoUpdate` and retry it (bounded + delayed) when it fails.

## Why
A failed `requestConsentInfoUpdate` previously only logged. For a first-time EEA user, a transient network error left `canRequestAds()` false for the whole session — no ads until a later launch. Now it retries up to `MAX_CONSENT_RETRY_COUNT` (3) times, `CONSENT_RETRY_DELAY_MS` (3s) apart, so a momentary failure doesn't cost impressions.

## Notes
- Retry budget resets each `initAds` (per launch).
- The delayed retry re-checks `!isFinishing && !isDestroyed` before touching the Activity.
- Constants are tunable; open to a different backoff if you'd prefer exponential.

Closes #4833