### PR TITLE
[Oztechan/CCC#4835] Add UMP consent flow to iOS for GDPR compliance

### DIFF
--- a/ios/CCC/Application.swift
+++ b/ios/CCC/Application.swift
@@ -8,6 +8,7 @@
 
 import FirebaseCore
 import GoogleMobileAds
+import UserMessagingPlatform
 import Provider
 import SwiftUI
 import BackgroundTasks
@@ -21,6 +22,7 @@ var logger: KermitLogger = {
 struct Application: App {
     @Environment(\.scenePhase) private var scenePhase
     @State private var isWatcherAlertShown = false
+    @State private var didRequestConsent = false
     @StateObject var observable = ObservableSEEDViewModel<
         MainState,
         MainEffect,
@@ -38,10 +40,6 @@ struct Application: App {
         FirebaseApp.configure()
 
         logger.i(message: { "Application init" })
-
-        GADMobileAds.sharedInstance().start(completionHandler: nil)
-        GADMobileAds.sharedInstance().applicationMuted = true
-        GADMobileAds.sharedInstance().applicationVolume = 0
 
         UITableView.appearance().tableHeaderView = UIView(frame: CGRect(
             x: 0,
@@ -68,6 +66,7 @@ struct Application: App {
                 }
             }.onAppear {
                 observable.startObserving()
+                requestConsentIfNeeded()
             }.onDisappear {
                 observable.stopObserving()
             }.onReceive(observable.effect) {
@@ -108,6 +107,40 @@ struct Application: App {
         default:
             logger.i(message: { "Application unknown effect" })
         }
+    }
+
+    private func requestConsentIfNeeded() {
+        guard !didRequestConsent else { return }
+        didRequestConsent = true
+
+        let parameters = UMPRequestParameters()
+        UMPConsentInformation.sharedInstance.requestConsentInfoUpdate(with: parameters) { requestError in
+            if let requestError = requestError {
+                logger.i(message: { "Application consent info update failed \(requestError.localizedDescription)" })
+            }
+
+            UMPConsentForm.loadAndPresentIfRequired(from: WindowUtil.getCurrentController()) { formError in
+                if let formError = formError {
+                    logger.i(message: { "Application consent form failed \(formError.localizedDescription)" })
+                }
+                startAdsIfAllowed()
+            }
+        }
+
+        // Returning users with prior consent (and users where consent isn't required) can
+        // start ads immediately, in parallel with the consent info update.
+        startAdsIfAllowed()
+    }
+
+    private func startAdsIfAllowed() {
+        guard UMPConsentInformation.sharedInstance.canRequestAds else {
+            logger.v(message: { "Application ads not started, cannot request ads" })
+            return
+        }
+
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        GADMobileAds.sharedInstance().applicationMuted = true
+        GADMobileAds.sharedInstance().applicationVolume = 0
     }
 
     private func scheduleAppRefresh() {

--- a/ios/CCC/UI/Components/AdaptiveBannerAdView.swift
+++ b/ios/CCC/UI/Components/AdaptiveBannerAdView.swift
@@ -7,6 +7,7 @@
 //
 
 import GoogleMobileAds
+import UserMessagingPlatform
 import SwiftUI
 import UIKit
 import Provider
@@ -37,7 +38,9 @@ struct AdaptiveBannerAdView: UIViewControllerRepresentable {
         viewController.view.frame = CGRect(origin: .zero, size: adSize.size)
 
         bannerView.adSize = adSize
-        bannerView.load(GADRequest())
+        if UMPConsentInformation.sharedInstance.canRequestAds {
+            bannerView.load(GADRequest())
+        }
 
         return viewController
     }

--- a/ios/CCC/Util/InterstitialAd.swift
+++ b/ios/CCC/Util/InterstitialAd.swift
@@ -7,10 +7,16 @@
 //
 
 import GoogleMobileAds
+import UserMessagingPlatform
 import Provider
 
 final class InterstitialAd: NSObject, GADFullScreenContentDelegate {
     func show() {
+        guard UMPConsentInformation.sharedInstance.canRequestAds else {
+            logger.v(message: { "InterstitialAd not showed, cannot request ads" })
+            return
+        }
+
         GADInterstitialAd.load(
             withAdUnitID: SecretUtil.getSecret(key: "INTERSTITIAL_AD_ID"),
             request: GADRequest(),


### PR DESCRIPTION
## ⚠️ Best-effort — DO NOT auto-merge; needs iOS build + on-device verification

Written without a local iOS build. Please verify via the iOS CI job and on an EEA-region device/emulator before merging.

## What
Adds the iOS UMP consent flow (mirrors Android):
- `Application`: request `UMPConsentInformation` update, present the form via `UMPConsentForm.loadAndPresentIfRequired(from:)`, and start `GADMobileAds` **only** when `canRequestAds` (removed the unconditional `start()` from `init`).
- `AdaptiveBannerAdView`: only `load()` when `canRequestAds`.
- `InterstitialAd`: guard `show()` on `canRequestAds`.

## 🔧 Required manual step (I couldn't safely edit the Xcode project)
`UserMessagingPlatform` is **not linked to the CCC target** (only `GoogleMobileAds` is). Before this compiles, add the **UserMessagingPlatform** product to the CCC target in Xcode (it's already a resolved SPM dependency). Without this, `import UserMessagingPlatform` fails.

## Verify
- [ ] Add UserMessagingPlatform product to target; iOS build passes
- [ ] EEA device: consent form appears on first launch; ads only after consent
- [ ] Non-EEA device: ads appear as before (no form)
- [ ] Consent form presents from the correct root VC (timing from `.onAppear`)

## Heads-up on intent
This is a **compliance** change: EEA users who reject consent will (correctly) become ad-free — the opposite of the "no ad-free users" goal, but legally required. Also: banners still reserve their slot when `canRequestAds` is false (empty space) — same cosmetic as the Android pre-fix; can be tightened in the ad-load-failure ticket.

Closes #4835