### PR TITLE
[Oztechan/CCC#4837] Collapse banner slot when the ad fails to load (Android)

### DIFF
--- a/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/google/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -88,7 +88,9 @@ internal class AdManagerImpl(context: Context) : AdManager {
     override fun getBannerAd(
         context: Context,
         adId: String,
-        maxHeightInDp: Float
+        maxHeightInDp: Float,
+        onAdLoaded: () -> Unit,
+        onAdFailedToLoad: () -> Unit
     ): BannerAdView {
         Logger.v { "AdManagerImpl getBannerAd" }
 
@@ -116,11 +118,17 @@ internal class AdManagerImpl(context: Context) : AdManager {
             setAdSize(finalAdSize)
             adUnitId = adId
             adListener = object : AdListener() {
+                override fun onAdLoaded() {
+                    super.onAdLoaded()
+                    onAdLoaded()
+                }
+
                 override fun onAdFailedToLoad(adError: LoadAdError) {
                     super.onAdFailedToLoad(adError)
                     Exception("AdManagerImpl getBannerAd onAdFailedToLoad ${adError.message}").let {
                         Logger.e(it) { it.message.orEmpty() }
                     }
+                    onAdFailedToLoad()
                 }
             }
             loadAd(adRequest)

--- a/android/core/ad/src/huawei/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
+++ b/android/core/ad/src/huawei/kotlin/com/oztechan/ccc/android/core/ad/AdManagerImpl.kt
@@ -40,13 +40,29 @@ internal class AdManagerImpl : AdManager {
     override fun getBannerAd(
         context: Context,
         adId: String,
-        maxHeightInDp: Float
+        maxHeightInDp: Float,
+        onAdLoaded: () -> Unit,
+        onAdFailedToLoad: () -> Unit
     ): BannerAdView {
         Logger.v { "AdManagerImpl getBannerAd" }
 
         val adView = BannerView(context).apply {
             this.adId = adId
             bannerAdSize = BannerAdSize.BANNER_SIZE_SMART
+            adListener = object : AdListener() {
+                override fun onAdLoaded() {
+                    super.onAdLoaded()
+                    onAdLoaded()
+                }
+
+                override fun onAdFailed(errorCode: Int) {
+                    super.onAdFailed(errorCode)
+                    Exception("AdManagerImpl getBannerAd onAdFailed $errorCode").let {
+                        Logger.e(it) { it.message.orEmpty() }
+                    }
+                    onAdFailedToLoad()
+                }
+            }
             loadAd(adParam)
         }
 

--- a/android/core/ad/src/main/kotlin/com/oztechan/ccc/android/core/ad/AdManager.kt
+++ b/android/core/ad/src/main/kotlin/com/oztechan/ccc/android/core/ad/AdManager.kt
@@ -16,7 +16,9 @@ interface AdManager {
     fun getBannerAd(
         context: Context,
         adId: String,
-        maxHeightInDp: Float
+        maxHeightInDp: Float,
+        onAdLoaded: () -> Unit,
+        onAdFailedToLoad: () -> Unit
     ): BannerAdView
 
     fun showInterstitialAd(

--- a/android/ui/mobile/src/main/kotlin/com/oztechan/ccc/android/ui/mobile/util/ViewExtensions.kt
+++ b/android/ui/mobile/src/main/kotlin/com/oztechan/ccc/android/ui/mobile/util/ViewExtensions.kt
@@ -70,7 +70,9 @@ fun FrameLayout.buildBanner(
         adManager.getBannerAd(
             context,
             adId,
-            context.resources.getDimension(R.dimen.ads_banner_height)
+            context.resources.getDimension(R.dimen.ads_banner_height),
+            onAdLoaded = { isVisible = true },
+            onAdFailedToLoad = { isGone = true }
         )
     )
 } else {


### PR DESCRIPTION
## What
Thread `onAdLoaded` / `onAdFailedToLoad` hooks through `AdManager.getBannerAd` so `buildBanner` can hide the banner slot on failure and restore it on a (later) successful load.

- `AdManager`/Google/Huawei: banner listener now forwards load-success and load-failure.
- `buildBanner`: `onAdFailedToLoad = { isGone = true }`, `onAdLoaded = { isVisible = true }`.

## Why
On no-fill/network failure the banner container kept its reserved height and showed empty. Now it collapses; and because it restores on `onAdLoaded`, it stays correct when **AdMob banner auto-refresh** later fills the slot (recommended to enable in the AdMob console alongside this).

## Notes
- Android only. iOS collapse needs a SwiftUI refactor (binding) and rides with the retry ticket.
- Tradeoff: collapsing removes layout-reserved space, so the content shifts when a banner appears/disappears. If you'd rather keep the space reserved, say so and I'll drop the collapse and keep only the restore.

Closes #4837