### PR TITLE
[Oztechan/CCC#4839] Cancel previous interstitial timer before starting a new one

### DIFF
--- a/client/viewmodel/main/src/commonMain/kotlin/com/oztechan/ccc/client/viewmodel/main/MainViewModel.kt
+++ b/client/viewmodel/main/src/commonMain/kotlin/com/oztechan/ccc/client/viewmodel/main/MainViewModel.kt
@@ -55,6 +55,8 @@ class MainViewModel(
     }
 
     private fun setupInterstitialAdTimer() {
+        // Cancel any running timer so repeated foregrounds can't stack multiple timers.
+        data.adJob.cancel()
         data.adVisibility = true
 
         data.adJob = viewModelScope.launch {

--- a/client/viewmodel/main/src/commonTest/kotlin/com/oztechan/ccc/client/viewmodel/main/MainViewModelTest.kt
+++ b/client/viewmodel/main/src/commonTest/kotlin/com/oztechan/ccc/client/viewmodel/main/MainViewModelTest.kt
@@ -240,6 +240,43 @@ internal class MainViewModelTest {
     }
 
     @Test
+    fun `onAppForeground twice cancels the previous interstitial timer`() = runTest {
+        every { reviewConfigService.config }
+            .returns(ReviewConfig(0, 0L))
+
+        every { adConfigService.config }
+            .returns(AdConfig(0, 0, 0L, 0L))
+
+        every { appStorage.sessionCount }
+            .returns(Random.nextLong())
+
+        every { appConfigRepository.checkAppUpdate(false) }
+            .returns(null)
+
+        every { adControlRepository.shouldShowInterstitialAd() }
+            .returns(true)
+
+        every { appConfigRepository.shouldShowAppReview() }
+            .returns(false)
+
+        every { appStorage.premiumEndDate }
+            .returns(nowAsLong() - 1.seconds.inWholeMilliseconds)
+
+        with(viewModel) {
+            event.onAppForeground()
+            val previousJob = data.adJob
+            assertTrue { previousJob.isActive }
+
+            event.onAppForeground()
+
+            assertTrue { previousJob.isCancelled }
+            assertTrue { data.adJob.isActive }
+
+            data.adJob.cancel()
+        }
+    }
+
+    @Test
     fun `onAppForeground checkAppUpdate nothing happens when check update returns null`() =
         with(viewModel) {
             val mockSessionCount = Random.nextLong()


### PR DESCRIPTION
## What
`setupInterstitialAdTimer()` now cancels the existing `data.adJob` before launching a new one.

## Why
Two `onAppForeground()` calls without an intervening `onAppBackground()` (a lifecycle quirk) would stack multiple timer coroutines, firing interstitials too often. `onAppBackground()` already cancels the job on the normal path; this makes it robust regardless of lifecycle pairing.

## Test
Added `onAppForeground twice cancels the previous interstitial timer` — asserts the first job is cancelled and only the new one is active after a second foreground (fails on the old code).

Closes #4839