### PR TITLE
[Oztechan/CCC#4851] Upload iOS dSYMs from the macOS build lanes

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -65,6 +65,11 @@ platform :ios do
                 profile: "match AdHoc com.oztechan.ccc",
                 configuration: "Release"
             )
+            upload_symbols_to_crashlytics(
+                app_id: ENV["IOS_RELEASE_FIREBASE_APP_ID"],
+                dsym_path: "../ios/CCC.app.dSYM.zip",
+                binary_path: "../ios/scripts/upload-symbols",
+            )
         end
 
         lane :buildDebug do
@@ -74,6 +79,11 @@ platform :ios do
                 match_type: "adhoc",
                 profile: "match AdHoc com.oztechan.ccc.debug",
                 configuration: "Debug"
+            )
+            upload_symbols_to_crashlytics(
+                app_id: ENV["IOS_DEBUG_FIREBASE_APP_ID"],
+                dsym_path: "../ios/CCC_I.app.dSYM.zip",
+                binary_path: "../ios/scripts/upload-symbols",
             )
         end
 
@@ -100,10 +110,6 @@ platform :ios do
                 firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],
                 ipa_path: "../ios/CCC.ipa"
             )
-            upload_symbols_to_crashlytics(
-                dsym_path: "../ios/CCC.app.dSYM.zip",
-                binary_path: "../ios/scripts/upload-symbols",
-            )
         end
 
         lane :distributeDebug do
@@ -113,10 +119,6 @@ platform :ios do
                 release_notes: changelog_from_git_commits(commits_count: 1),
                 firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],
                 ipa_path: "../ios/CCC_I.ipa"
-            )
-            upload_symbols_to_crashlytics(
-                dsym_path: "../ios/CCC_I.app.dSYM.zip",
-                binary_path: "../ios/scripts/upload-symbols",
             )
         end
 


### PR DESCRIPTION
Closes #4851

## What

Moves `upload_symbols_to_crashlytics` from `distributeRelease` / `distributeDebug` into `buildRelease` / `buildDebug`.

One file, `ios/fastlane/Fastfile`. **No workflow changes and no change to the job graph** — `XCodeBuild` (`macos-26`) → `DistributeIOS` (`ubuntu-24.04`), exactly as today.

## Why

`ios/scripts/upload-symbols` is a Mach-O binary, but it was being invoked from the distribute lanes, which run on `ubuntu-24.04`. It could never execute there. The duration proves it — a real dSYM upload takes seconds:

| Run | Date | "Uploading…" → error |
| --- | --- | --- |
| 30522354900 | Jul 30 | 3.7 ms |
| 30682404840 | Aug 1 | 4.1 ms |
| 32205969666 | Aug 19 | 3.7 ms |
| 32582790229 | Aug 22 | 2.8 ms |

Every run logs `Shell command exited with exit status 2` followed by `Successfully uploaded dSYM files to Crashlytics 💯`.

It surfaced on Aug 20 because the runner image bumped `20260810.271.1` → `20260816.277.1`, upgrading system fastlane 2.237.0 → 2.238.0. That release made per-dSYM results reflect real failure, so the action's aggregate check now reaches its unconditional `UI.user_error!`.

`store_build` has the same call and has never failed — it runs on `macos-26` via `release.yml`. That is what confirmed the diagnosis.

## Not a symbolication outage

dSYM upload has been working via the Crashlytics run-script build phase (`project.pbxproj:483-501`), which uses the documented `inputPaths` for automatic upload and runs during `gym` on macOS. Its validation step is synchronous and fails the Xcode build on a bad environment, so green iOS builds prove the upload is being launched with a valid config.

The fastlane call was therefore both redundant and broken. This PR makes the working path explicit and visible instead of backgrounded to `/dev/null`.

## Why not a separate job

The dSYM is on disk the moment `gym` finishes. A separate job would download a 17.6 MB artifact to use one file from it, add a macOS runner boot to the critical path, and force `DistributeIOS` to serialize behind it (that job deletes the artifact). In exchange it buys no independent retry — a dSYM failure means re-running the build regardless.

`DistributeIOS` stays its own job because Firebase auth or quota can fail while the build is fine.

## Note on `app_id`

Passed explicitly (`IOS_RELEASE_FIREBASE_APP_ID` / `IOS_DEBUG_FIREBASE_APP_ID`, already in the workflow env) rather than letting the action glob for `GoogleService-Info.plist`, so the lane does not depend on which secret files a given job decrypted.

## Verified / not verified

Verified locally: `ruby -c` passes; dSYM paths match the artifact paths at `main.yml:186,196`; `store_build` already uses these paths successfully on macOS.

Not verified: this only truly exercises on a GitHub macOS runner with signing, so CI on this PR is the real test. `ios/scripts/upload-symbols` is the 2022 copy (558 KB vs the SDK's current 810 KB) and will genuinely execute for the first time — if it is too old for Firebase's API, it will now fail loudly rather than silently.

## Follow-ups

- Remove the redundant run-script build phase once this is confirmed green (uploads dedupe by dSYM UUID, so both running is harmless meanwhile)
- `bundle exec fastlane`, so the `ios/Gemfile` pin applies instead of the runner image — needs a bundler setup step, so it belongs in its own PR